### PR TITLE
Fix #2

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -102,7 +102,7 @@ MYSQL_ADD_EXECUTABLE(mysqlredo
   mylog0log.cc
   mymtr0log.cpp
   INCLUDE_DIRECTORIES ../storage/innobase/include ../storage/innobase
-  LINK_LIBRARIES innobase minchassis # mysqlservices sql_main sql_dd mysys
+  LINK_LIBRARIES innobase mysql_server_component_services minchassis # mysqlservices sql_main sql_dd mysys
 )
 ADD_DEPENDENCIES(mysqlredo minchassis)
 ADD_DEPENDENCIES(mysqlredo innobase minchassis)


### PR DESCRIPTION
Fix https://github.com/tom--bo/mysqlredo/issues/2 by adding `libmysql_server_component_services` .
See also, https://gist.github.com/yoku0825/ee2f256c10f692c9e93a1f5ece04b0db