### PR TITLE
Update innodb_log.h

### DIFF
--- a/client/innodb_log.h
+++ b/client/innodb_log.h
@@ -21,7 +21,7 @@ public:
 
 class NullStream : public std::streambuf {
 public:
-  int overflow(int c) {
+  int overflow(int c) override final {
     return c;
   }
 };


### PR DESCRIPTION
To suppress the following warning (`suggest-override`)

```c++
nikezono@nikezono ~/m/build> ninja mysqlredo
[1966/2603] Building CXX object client/CMakeFiles/mysqlredo.dir/mysqlredo.cc.o
FAILED: client/CMakeFiles/mysqlredo.dir/mysqlredo.cc.o
/opt/rh/devtoolset-11/root/usr/bin/g++  -DBOOST_NO_CXX98_FUNCTION_BASE -DCOMPILER_HINTS -DHAVE_CONFIG_H -DHAVE_FALLOC_FL_ZERO_RANGE=1 -DHAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE=1 -DHAVE_IB_GCC_ATOMIC_THREAD_FENCE=1 -DHAVE_IB_GCC_SYNC_SYNCHRONISE=1 -DHAVE_IB_LINUX_FUTEX=1 -DHAVE_LZ4=1 -DHAVE_NANOSLEEP=1 -DHAVE_SCHED_GETCPU=1 -DLZ4_DISABLE_DEPRECATE_WARNINGS -DMUTEX_EVENT -DRAPIDJSON_NO_SIZETYPEDEFINE -DRAPIDJSON_SCHEMA_USE_INTERNALREGEX=0 -DRAPIDJSON_SCHEMA_USE_STDREGEX=1 -DUNIV_LINUX -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_USE_MATH_DEFINES -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I. -Iinclude -I../ -I../include -I../client/include -I../storage/innobase -I../storage/innobase/include -I../storage/innobase/handler -I../client/../storage/innobase/include -I../client/../storage/innobase -isystem ../extra/rapidjson/include -isystem ../extra/protobuf/protobuf-3.19.4/src -isystem ../extra/lz4/lz4-1.9.4/lib -isystem ../extra/libedit/libedit-20210910-3.1/src/editline -isystem ../extra/zstd/zstd-1.5.0/lib -isystem extra/zlib/zlib-1.2.13 -isystem ../extra/zlib/zlib-1.2.13 -std=c++17 -fno-omit-frame-pointer -ftls-model=initial-exec -B/opt/rh/devtoolset-11/root/usr/bin  -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute -Woverloaded-virtual -Wcast-qual -Wimplicit-fallthrough=5 -Wstringop-truncation -Wsuggest-override -Wmissing-include-dirs -Wextra-semi -Wlogical-op -Werror -Wno-unused-parameter -Wno-cast-qual -DSAFE_MUTEX -DENABLED_DEBUG_SYNC -g -DUNIV_DEBUG -fPIE   -Wshadow=local -MD -MT client/CMakeFiles/mysqlredo.dir/mysqlredo.cc.o -MF client/CMakeFiles/mysqlredo.dir/mysqlredo.cc.o.d -o client/CMakeFiles/mysqlredo.dir/mysqlredo.cc.o -c ../client/mysqlredo.cc
In file included from ../client/mysqlredo.cc:24:
../client/innodb_log.h:24:7: error: ‘virtual int NullStream::overflow(int)’ can be marked override [-Werror=suggest-override]
   24 |   int overflow(int c) {
      |       ^~~~~~~~
cc1plus: all warnings being treated as errors
```
